### PR TITLE
Add Program Aided Prompting notebook

### DIFF
--- a/program_aided_prompting.ipynb
+++ b/program_aided_prompting.ipynb
@@ -1,0 +1,130 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Program Aided Prompting Example\n",
+    "\n",
+    "This notebook demonstrates a realistic workflow for **Program Aided Prompting (PAP)**. We will let a language model generate Python code to analyze a small sales dataset, execute that code programmatically, and then feed the results back to the model for a final summary."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We use the `openai` Python package to access a GPT model. Set the `OPENAI_API_KEY` environment variable before running these cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import openai\n",
+    "import pandas as pd\n",
+    "\n",
+    "openai.api_key = os.getenv('OPENAI_API_KEY')\n",
+    "assert openai.api_key, 'Please set OPENAI_API_KEY'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('sales_data.csv')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Ask the model for analysis code\n",
+    "We prompt the model with a short description of the data and ask it to write Python code that returns:\n",
+    "1. Total sales across all categories\n",
+    "2. The name of the category with the highest sales\n",
+    "3. A bar chart visualizing the sales by category"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "system_prompt = 'You are a helpful data analyst who writes clean Python code.'\n",
+    "user_prompt = f'The DataFrame `df` contains two columns: `category` and `sales`.\nPlease provide Python code that computes the total sales, finds the top category, and draws a bar chart of sales by category.'\n",
+    "response = openai.ChatCompletion.create(model='gpt-3.5-turbo', messages=[{'role':'system','content':system_prompt},{'role':'user','content':user_prompt}])\n",
+    "generated_code = response['choices'][0]['message']['content']\n",
+    "print(generated_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Execute the generated code\n",
+    "We use `exec` to run the code from the model in a restricted namespace and capture the resulting variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "namespace = {'df': df}\n",
+    "exec(generated_code, namespace)\n",
+    "total_sales = namespace.get('total_sales')\n",
+    "top_category = namespace.get('top_category')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Summarize the results\n",
+    "Finally, we feed the numerical results back into the model and request a short managerial summary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "summary_prompt = f'The total sales were {total_sales} units. The top category was {top_category}. Write a short summary for a manager.'\n",
+    "summary_response = openai.ChatCompletion.create(model='gpt-3.5-turbo', messages=[{'role':'user','content':summary_prompt}])\n",
+    "summary = summary_response['choices'][0]['message']['content']\n",
+    "print(summary)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sales_data.csv
+++ b/sales_data.csv
@@ -1,0 +1,11 @@
+category,sales
+Books,100
+Electronics,250
+Clothing,150
+Toys,300
+Furniture,80
+Sports,120
+Beauty,90
+Groceries,200
+Shoes,160
+Garden,110


### PR DESCRIPTION
## Summary
- create a realistic Program Aided Prompting example
- add small sales dataset used by the notebook

## Testing
- `jupyter nbconvert --to markdown program_aided_prompting.ipynb`


------
https://chatgpt.com/codex/tasks/task_e_6878c97389cc8331b96af4d4c3a12866