### PR TITLE
Add basic embeddings mini lab

### DIFF
--- a/basic_embeddings_example.ipynb
+++ b/basic_embeddings_example.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "823b4337",
+   "metadata": {},
+   "source": [
+    "# Basic Embeddings Mini-Lab\n",
+    "\n",
+    "This short notebook demonstrates how to create sentence embeddings and search for similar questions using FAISS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7503885e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q sentence-transformers faiss-cpu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f41b543",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sentence_transformers import SentenceTransformer\n",
+    "import faiss, numpy as np, pandas as pd\n",
+    "\n",
+    "questions = [\n",
+    "    'Explain Kirchhoff’s voltage law with one example.',\n",
+    "    'Describe the working of a J-K flip-flop and draw its truth table.',\n",
+    "    'What is normalization in relational databases? List its benefits.',\n",
+    "    'Derive the efficiency of a class-B push-pull amplifier.',\n",
+    "    'Define polymorphism in OOP and give two real-life examples.'\n",
+    "]\n",
+    "\n",
+    "model = SentenceTransformer('paraphrase-MiniLM-L6-v2')\n",
+    "embeddings = model.encode(questions, convert_to_numpy=True)\n",
+    "print('Shape of embedding matrix:', embeddings.shape)\n",
+    "\n",
+    "d = embeddings.shape[1]\n",
+    "index = faiss.IndexFlatIP(d)\n",
+    "faiss.normalize_L2(embeddings)\n",
+    "index.add(embeddings)\n",
+    "\n",
+    "def ask(query, top_k=2):\n",
+    "    vec = model.encode([query], convert_to_numpy=True)\n",
+    "    faiss.normalize_L2(vec)\n",
+    "    D, I = index.search(vec, top_k)\n",
+    "    hits = pd.DataFrame({'Similarity': D[0], 'Matched question': [questions[i] for i in I[0]]})\n",
+    "    return hits\n",
+    "\n",
+    "print('Ready! Type ask(\\'your question\\') below.')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e07a7699",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ask('Give an example of polymorphism and explain it.')"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a short Jupyter notebook `basic_embeddings_example.ipynb`
- demonstrates how to create sentence embeddings and search with FAISS

## Testing
- `pytest -q`
- `jupyter nbconvert --execute` *(failed: network blocked during model download)*

------
https://chatgpt.com/codex/tasks/task_e_6878e94536ac8331ad987f987b17ac4b